### PR TITLE
changes memlimit to interactive

### DIFF
--- a/packages/dpki-lite/lib/util.js
+++ b/packages/dpki-lite/lib/util.js
@@ -90,7 +90,7 @@ function pwHash (pass, salt) {
     _sodium.ready.then((_) => {
       const opt = {
         opslimit: _sodium.crypto_pwhash_OPSLIMIT_SENSITIVE,
-        memlimit: _sodium.crypto_pwhash_MEMLIMIT_SENSITIVE,
+        memlimit: _sodium.crypto_pwhash_MEMLIMIT_INTERACTIVE,
         algorithm: _sodium.crypto_pwhash_ALG_ARGON2ID13,
         keyLength: 32
       }


### PR DESCRIPTION
Closes #4 

I was previously getting around this with a git patch but I see the need to make this module npm install-able soon.

The errors returned by libsodium are very unhelpful so I have no idea why it is crashing with the large memory use setting. 

Would it be ok to have this setting for closed alpha or at least until we figure out why it is not working with the suggested settings? 